### PR TITLE
Add conversion from note notation to wave notation

### DIFF
--- a/src/metronome_core/audio_engine.py
+++ b/src/metronome_core/audio_engine.py
@@ -46,8 +46,8 @@ class AudioEngine:
 
   def create_rhythm_waveform(self, rhythm: Iterable[Wave]) -> Waveform:
     waveforms: list[Waveform] = []
-    for index, note in enumerate(rhythm):
-      if index % 2 == 0:
+    for note in rhythm:
+      if note.frequency != 0:
         waveform = self._generate_sine_wave(note.frequency, note.duration)
       else:
         waveform = self._generate_silence(note.duration)

--- a/src/metronome_core/notes.py
+++ b/src/metronome_core/notes.py
@@ -10,6 +10,7 @@ NoteValue: TypeAlias = float | int
 
 SECONDS_PER_MINUTE = 60
 CONCERT_PITCH = 440
+SILENCE_PITCH = 0
 BEAT_DIVISOR = 1 / 4
 BEAT_DIVISOR_COMPLIMENT = 1 - BEAT_DIVISOR
 
@@ -51,7 +52,7 @@ class NoteSequence:
       accent = audio_engine.Wave(CONCERT_PITCH, total_duration * BEAT_DIVISOR)
       waves.append(accent)
       silence = audio_engine.Wave(
-          CONCERT_PITCH, total_duration * BEAT_DIVISOR_COMPLIMENT
+          SILENCE_PITCH, total_duration * BEAT_DIVISOR_COMPLIMENT
       )
       waves.append(silence)
     return waves

--- a/src/metronome_core/notes.py
+++ b/src/metronome_core/notes.py
@@ -3,9 +3,15 @@ class to organize note groups."""
 from typing import TypeAlias
 from collections.abc import Iterable
 
+from metronome_core import audio_engine
 
 TimeSignature: TypeAlias = tuple[int, int]
 NoteValue: TypeAlias = float | int
+
+SECONDS_PER_MINUTE = 60
+CONCERT_PITCH = 440
+BEAT_DIVISOR = 1 / 4
+BEAT_DIVISOR_COMPLIMENT = 1 - BEAT_DIVISOR
 
 
 class Note:
@@ -27,6 +33,8 @@ class QuarterNote(Note):
 
 
 class NoteSequence:
+  """A fully defined series of sounds from which a metronome sound file can
+  be generated for the audio_engine.AudioEngine."""
 
   def __init__(
       self, tempo: int, notes: Iterable[Note], time_signature: TimeSignature
@@ -34,3 +42,16 @@ class NoteSequence:
     self.tempo = tempo
     self.notes = notes
     self.time_signature = time_signature
+
+  def to_waves(self) -> list[audio_engine.Wave]:
+    waves: list[audio_engine.Wave] = []
+    second_per_value = SECONDS_PER_MINUTE / self.tempo
+    for note in self.notes:
+      total_duration = note.value * second_per_value
+      accent = audio_engine.Wave(CONCERT_PITCH, total_duration * BEAT_DIVISOR)
+      waves.append(accent)
+      silence = audio_engine.Wave(
+          CONCERT_PITCH, total_duration * BEAT_DIVISOR_COMPLIMENT
+      )
+      waves.append(silence)
+    return waves

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -40,3 +40,9 @@ def test_to_waves_common_time_quarter_notes_silence_between_notes():
   for index, wave in enumerate(waves):
     if index % 2 == 1:
       assert wave.frequency == 0
+
+
+def test_to_waves_common_time_quarter_notes_silence_at_end():
+  waves = [audio_engine.Wave(440, 0.25), audio_engine.Wave(0, 0.75)] * 4
+  final_wave = waves[-1]
+  assert final_wave.frequency == 0

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,35 @@
+# pylint: disable=[missing-module-docstring, missing-class-docstring, protected-access, redefined-outer-name]
+
+import pytest
+
+from metronome_core import notes
+from metronome_core import audio_engine
+
+
+@pytest.fixture
+def bpm_60():
+  return 60
+
+
+@pytest.fixture
+def quarter_note_measure():
+  return [notes.QuarterNote()] * 4
+
+
+@pytest.fixture
+def common_time():
+  return (4, 4)
+
+
+@pytest.fixture
+def quarter_note_60_bpm_note_sequence(
+    bpm_60, quarter_note_measure, common_time
+):
+  return notes.NoteSequence(bpm_60, quarter_note_measure, common_time)
+
+
+def test_to_waves_common_time_quarter_notes(quarter_note_60_bpm_note_sequence):
+  expected = [audio_engine.Wave(440, 0.25), audio_engine.Wave(0, 0.75)] * 4
+  note_sequence = quarter_note_60_bpm_note_sequence
+  actual = note_sequence.to_waves()
+  assert actual == expected

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -33,3 +33,10 @@ def test_to_waves_common_time_quarter_notes(quarter_note_60_bpm_note_sequence):
   note_sequence = quarter_note_60_bpm_note_sequence
   actual = note_sequence.to_waves()
   assert actual == expected
+
+
+def test_to_waves_common_time_quarter_notes_silence_between_notes():
+  waves = [audio_engine.Wave(440, 0.25), audio_engine.Wave(0, 0.75)] * 4
+  for index, wave in enumerate(waves):
+    if index % 2 == 1:
+      assert wave.frequency == 0


### PR DESCRIPTION
## What?

Add way to convert from note notation to wave (and waveform).
## Why?

Translation method for front-end input to back-end engine.
## How?

Calculate the length of each note in note notation and generate a wave corresponding to the accent of the beat and the following silence.
## Testing?

Added testing methods for conversion
## Screenshots (optional)

0
## Anything Else?
To be implemented in the front-end